### PR TITLE
Fix redundant user ID check

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -78,8 +78,8 @@ func TestClient_ListUsers(t *testing.T) {
     }
     // Compare each user
     for i, u := range users {
-        if u.ID != int(sample[i]["id"].(int)) && u.ID != int(sample[i]["id"].(int)) {
-            // unify type but we can't introspect; we know sample uses int.
+        if u.ID != sample[i]["id"].(int) {
+            t.Errorf("user %d ID mismatch: got %d, want %d", i, u.ID, sample[i]["id"].(int))
         }
         // We'll compare all fields manually using reflect.DeepEqual on a map
         expected := &User{


### PR DESCRIPTION
## Summary
- streamline `TestClient_ListUsers` by replacing a redundant condition

## Testing
- `go test ./...` *(fails: missing go.sum entries for hashicorp modules)*

------
https://chatgpt.com/codex/tasks/task_e_687a2c0ad8e88329a8f000ee17afb37f